### PR TITLE
Reorder CODEOWNERS patterns to put .github dir ownership last

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,12 +5,12 @@
 # requested for review when someone opens a pull request.
 * @dav3r @jsf9k
 
-# These folks own any files in the .github directory at the root of
-# the repository and any of its subdirectories.
-/.github/ @dav3r @felddy @hillaryj @jsf9k @mcdonnnj
-
 # Let jsf9k own the sometimes-touchy AWS and Python playbooks, as well
 # as the packer.json file.
 /src/aws.yml @jsf9k
 /src/packer.json @jsf9k
 /src/python.yml @jsf9k
+
+# These folks own any files in the .github directory at the root of
+# the repository and any of its subdirectories.
+/.github/ @dav3r @felddy @hillaryj @jsf9k @mcdonnnj


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Reorder file patterns in CODEOWNERS to put .github ownership last.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##
We put it last because the last pattern that applies takes precedence and the .github directory is most important.

Thanks to @jsf9k for noticing this!

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
All pre-commit checks pass.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide)..
* [x] All new and existing tests pass.
