### PR TITLE
Add two playbooks that use amazon.aws.ssm_parameter to comment

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -7,7 +7,7 @@ collections:
   # Required by the following playbooks:
   # - ansible/vnc.yml (uses amazon.aws.ssm_parameter)
   # - ansible/wazuh_agent.yml (uses amazon.aws.ssm_parameter)
-  # - ansible/xfce.yml (uses amazon.awsmssm_parameter)
+  # - ansible/xfce.yml (uses amazon.aws.ssm_parameter)
   - amazon.aws
   # Required by the following Ansible roles:
   # - ansible-role-amazon-efs-utils (uses community.general.json_query

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -5,7 +5,9 @@
 # either (or both) can be an empty list, e.g., collections: [].
 collections:
   # Required by the following playbooks:
+  # - ansible/vnc.yml (uses amazon.aws.ssm_parameter)
   # - ansible/wazuh_agent.yml (uses amazon.aws.ssm_parameter)
+  # - ansible/xfce.yml (uses amazon.awsmssm_parameter)
   - amazon.aws
   # Required by the following Ansible roles:
   # - ansible-role-amazon-efs-utils (uses community.general.json_query


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds two playbooks that use `amazon.aws.ssm_parameter` to a comment.

## 💭 Motivation and context ##

These two playbooks should have been added to the comment previously but were missed.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.